### PR TITLE
Handle no reviews in a month

### DIFF
--- a/reviews-to-slack.py
+++ b/reviews-to-slack.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 
 from googleapiclient import discovery
 from googleapiclient import http
+from googleapiclient.errors import HttpError
 from oauth2client.service_account import ServiceAccountCredentials
 
 import dateutil.parser


### PR DESCRIPTION
Sometimes we don't have any ratings or reviews so there is no file (throws a 404). Shouldn't crash on that.
